### PR TITLE
call magit-save-some-buffers on test runs if present

### DIFF
--- a/ruby-test-mode.el
+++ b/ruby-test-mode.el
@@ -245,11 +245,12 @@ filename is a Ruby implementation file."
 (defun ruby-test-run ()
   "Run the current buffer's file as specification or unit test."
   (interactive)
+  (save-buffer)
   (let ((filename (ruby-test-find-file)))
     (if filename
         (progn
-          (if (fboundp 'magit-save-some-buffers)
-              (magit-save-some-buffers))
+          (if (fboundp 'magit-save-repository-buffers)
+              (magit-save-repository-buffers))
           (ruby-test-run-command (ruby-test-command filename)))
       (message ruby-test-not-found-message))))
 

--- a/ruby-test-mode.el
+++ b/ruby-test-mode.el
@@ -247,7 +247,10 @@ filename is a Ruby implementation file."
   (interactive)
   (let ((filename (ruby-test-find-file)))
     (if filename
-        (ruby-test-run-command (ruby-test-command filename))
+        (progn
+          (if (fboundp 'magit-save-some-buffers)
+              (magit-save-some-buffers))
+          (ruby-test-run-command (ruby-test-command filename)))
       (message ruby-test-not-found-message))))
 
 ;;;###autoload
@@ -259,9 +262,12 @@ as `ruby-test-run-file'"
     (let ((test-file-buffer (get-file-buffer filename)))
       (if (and filename
                test-file-buffer)
+        (progn
+          (if (fboundp 'magit-save-some-buffers)
+              (magit-save-some-buffers))
           (with-current-buffer test-file-buffer
             (let ((line (line-number-at-pos (point))))
-              (ruby-test-run-command (ruby-test-command filename line))))
+              (ruby-test-run-command (ruby-test-command filename line)))))
         (message ruby-test-not-found-message)))))
 
 (defun ruby-test-run-command (command)


### PR DESCRIPTION
I often was forgetting to save my test or implementation file after editing and running `ruby-test-run`, and it wasn't immediately clear that I was running against old code.

Since I use magit for everything, this adds a call to `magit-save-some-buffers` if present, but I'm sure having a fallback without git would be useful too... I could research that if you think it's useful.