### PR TITLE
Fix ruby-test-find-target-filename could found correct target file wh…

### DIFF
--- a/ruby-test-mode.el
+++ b/ruby-test-mode.el
@@ -188,9 +188,10 @@ second element."
                   exist-filename)
               (setq target-filename
                     (or (dolist (filename target-filename-candidates exist-filename)
-                          (setq exist-filename (if (file-exists-p filename)
+                          (unless exist-filename
+                            (setq exist-filename (if (file-exists-p filename)
                                                    filename
-                                                 nil)))
+                                                 nil))))
 			(car target-filename-candidates)))))
         (setq mapping (cdr mapping))))
     target-filename))

--- a/test/ruby-test-mode-test.el
+++ b/test/ruby-test-mode-test.el
@@ -13,7 +13,7 @@
   )
 
 (ert-deftest ruby-test-find-target-filename ()
-  (let ((mapping '(("\\(.*\\)\\(.rb\\)" "\\1_test.rb" "other/\\1_test.rb"))))
+  (let ((mapping '(("\\(.*\\)\\(.rb\\)" "\\1_test.rb" "other/\\1_test.rb" "third/\\1_test.rb"))))
     (should (equal "exists_test.rb" (ruby-test-find-target-filename "exists.rb" mapping)))
     (flet ((file-exists-p (filename)
                           (if (string-match "other" filename)


### PR DESCRIPTION
…en more than two candidate exist in some case.

Here is a example:
target-filename-candidates is a list which exist three path strings
("not_existed/path1.rb" "existed/path2.rb" "not_existed/path3")

For previous code base, following code will execute on every element in list.
(if (file-exists-p filename)
  filename
nil)

this will result in the dolist return nil. (because the last path is not exist.)
And, finally result in `(car target-filename-candidates)' will be used, this is not correct.