### PR TITLE
Use pcre rewrite mapper

### DIFF
--- a/Cask
+++ b/Cask
@@ -1,6 +1,7 @@
 (source melpa)
 
 (package-file "ruby-test-mode.el")
+(depends-on "pcre2el" "1.8")
 
 (development
  (depends-on "ert-runner" "0.7.0"))

--- a/test/ruby-test-mode-test.el
+++ b/test/ruby-test-mode-test.el
@@ -3,38 +3,57 @@
 (require 'ruby-test-mode)
 
 (ert-deftest ruby-test-unit-filename ()
-  (should (equal "test/controllers/path/controller_test.rb" (ruby-test-unit-filename "app/controllers/path/controller.rb")))
-
-  (should (equal "test/models/path/model_test.rb" (ruby-test-unit-filename "app/models/path/model.rb")))
-
-  (should (equal "test/file_test.rb" (ruby-test-unit-filename "lib/file.rb")))
-
-  (should (equal "path/file_test.rb" (ruby-test-unit-filename "path/file.rb")))
+  (should (equal "project/test/controllers/path/controller_test.rb"
+                 (ruby-test-unit-filename "project/app/controllers/path/controller.rb")))
+  (should (equal "project/test/models/path/model_test.rb"
+                 (ruby-test-unit-filename "project/app/models/path/model.rb")))
+  (should (equal "project/test/file_test.rb"
+                 (ruby-test-unit-filename "project/lib/file.rb")))
+  (should (equal "project/path/file_test.rb"
+                 (ruby-test-unit-filename "project/path/file.rb")))
   )
 
 (ert-deftest ruby-test-find-target-filename ()
-  (let ((mapping '(("\\(.*\\)\\(.rb\\)" "\\1_test.rb" "other/\\1_test.rb" "third/\\1_test.rb"))))
-    (should (equal "exists_test.rb" (ruby-test-find-target-filename "exists.rb" mapping)))
+  (let ((mapping '(("\\(.*\\)\\(.rb\\)" "\\1_test.rb" "other/\\1_test.rb"
+                    "third/\\1_test.rb"))))
+    (should (equal "exists_test.rb"
+                   (ruby-test-find-target-filename "exists.rb" mapping)))
     (flet ((file-exists-p (filename)
                           (if (string-match "other" filename)
                               t
                             nil)))
-      (should (equal "other/exists_test.rb" (ruby-test-find-target-filename "exists.rb" mapping))))))
+      (should (equal "other/exists_test.rb"
+                     (ruby-test-find-target-filename "exists.rb" mapping))))))
 
 (ert-deftest ruby-test-testcase-name ()
   (should (equal nil (ruby-test-testcase-name "setup" "def")))
-  (should (equal "test_with_question_mark_\\\\?" (ruby-test-testcase-name "\"test with question mark ?\"" "def")))
-  (should (equal "test_with_quotes_.*somewhere" (ruby-test-testcase-name "\"test with quotes ' somewhere\"" "def")))
-  (should (equal "test_with_parenthesis_.*somewhere.*" (ruby-test-testcase-name "\"test with parenthesis (somewhere)\"" "def")))
-  (should (equal "test with spaces from minitest" (ruby-test-testcase-name "test with spaces from minitest" "it")))
+  (should (equal "test_with_question_mark_\\\\?"
+                 (ruby-test-testcase-name "\"test with question mark ?\"" "def")))
+  (should (equal "test_with_quotes_.*somewhere"
+                 (ruby-test-testcase-name "\"test with quotes ' somewhere\"" "def")))
+  (should (equal "test_with_parenthesis_.*somewhere.*"
+                 (ruby-test-testcase-name "\"test with parenthesis (somewhere)\"" "def")))
+  (should (equal "test with spaces from minitest"
+                 (ruby-test-testcase-name "test with spaces from minitest" "it")))
   )
 
 (ert-deftest ruby-test-specification-filename ()
-  (should (equal "spec/models/file_spec.rb" (ruby-test-specification-filename "app/models/file.rb")))
-  (should (equal "spec/controllers/file_spec.rb" (ruby-test-specification-filename "app/controllers/file.rb")))
-  (should (equal "spec/helpers/file_spec.rb" (ruby-test-specification-filename "app/helpers/file.rb")))
-  (should (equal "spec/views/posts/new.html.erb_spec.rb" (ruby-test-specification-filename "app/views/posts/new.html.erb")))
-  (should (equal "spec/services/some_service/file_spec.rb" (ruby-test-specification-filename "app/services/some_service/file.rb")))
-  (should (equal "spec/lib/something/file_spec.rb" (ruby-test-specification-filename "lib/something/file.rb")))
-  (should (equal "spec/lib/some_lib/file_spec.rb" (ruby-test-specification-filename "lib/some_lib/file.rb")))
-  (should (equal "something/file_spec.rb" (ruby-test-specification-filename "something/file.rb"))))
+  (should (equal "project/spec/models/file_spec.rb"
+                 (ruby-test-specification-filename "project/app/models/file.rb")))
+  (should (equal "project/spec/controllers/file_spec.rb"
+                 (ruby-test-specification-filename "project/app/controllers/file.rb")))
+  (should (equal "project/spec/helpers/file_spec.rb"
+                 (ruby-test-specification-filename "project/app/helpers/file.rb")))
+  (should (equal "project/spec/views/posts/new.html.erb_spec.rb"
+                 (ruby-test-specification-filename "project/app/views/posts/new.html.erb")))
+  (should (equal "project/spec/services/some_service/file_spec.rb"
+                 (ruby-test-specification-filename "project/app/services/some_service/file.rb")))
+  (should (equal "project/spec/something/file_spec.rb"
+                 (ruby-test-specification-filename "project/lib/something/file.rb")))
+  (should (equal "project/spec/some_lib/file_spec.rb"
+                 (ruby-test-specification-filename "project/lib/some_lib/file.rb")))
+  (should (equal "project/something/file_spec.rb"
+                 (ruby-test-specification-filename "project/something/file.rb")))
+  (should (equal "project/spec/javascripts/file_spec.coffee"
+                 (ruby-test-specification-filename "project/app/assets/javascripts/file.coffee")))
+  )


### PR DESCRIPTION
This PR need #29 to be merged first to make following code work correct.
e.g.
```cl
((pcre-to-elisp "(.*)/lib/(.*)\\.rb$") 
"\\1/spec/lib/\\2_spec.rb" 
"\\1/spec/\\2_spec.rb" 
"\\1/test/lib/\\2_test.rb" 
"\\1/test/\\2_test.rb")
```
target path candidate is more than two.

if the first `"\\1/spec/lib/\\2_spec.rb"` not exist, and second `"\\1/spec/\\2_spec.rb"` exist, and `"\\1/test/lib/\\2_test.rb" ` not exist.
This will result in the the default (car list) `"\\1/spec/lib/\\2_spec.rb"` to be used.
this is not correct.
