### PR TITLE
ruby-test-run-at-point preserves position.

### DIFF
--- a/ruby-test-mode.el
+++ b/ruby-test-mode.el
@@ -267,17 +267,18 @@ second element."
 
 (defun ruby-test-find-testcase-at (file line)
   (with-current-buffer (get-file-buffer file)
-    (goto-char (point-min))
-    (forward-line (1- line))
-    (end-of-line)
-    (message "%s:%s" (current-buffer) (point))
-    (if (re-search-backward (concat "^[ \t]*\\(def\\|test\\|it\\|should\\)[ \t]+"
-                                    "\\([\"']\\(.*?\\)[\"']\\|" ruby-symbol-re "*\\)"
-                                    "[ \t]*") nil t)
-        (let ((name (or (match-string 3)
-                        (match-string 2)))
-              (method (match-string 1)))
-          (ruby-test-testcase-name name method)))))
+    (save-excursion
+      (goto-char (point-min))
+      (forward-line (1- line))
+      (end-of-line)
+      (message "%s:%s" (current-buffer) (point))
+      (if (re-search-backward (concat "^[ \t]*\\(def\\|test\\|it\\|should\\)[ \t]+"
+                                      "\\([\"']\\(.*?\\)[\"']\\|" ruby-symbol-re "*\\)"
+                                      "[ \t]*") nil t)
+          (let ((name (or (match-string 3)
+                          (match-string 2)))
+                (method (match-string 1)))
+            (ruby-test-testcase-name name method))))))
 
 (defun ruby-test-testcase-name (name method)
   "Returns the sanitized name of the test"

--- a/ruby-test-mode.el
+++ b/ruby-test-mode.el
@@ -288,14 +288,14 @@ second element."
     name)
    ((string= name "setup")
     nil)
-   ((string= method "def")
-    name)
    ((string-match "^[\"']\\(.*\\)[\"']$" name)
     (replace-regexp-in-string
      "\\?" "\\\\\\\\?"
      (replace-regexp-in-string
       "'_?\\|(_?\\|)_?" ".*"
-      (replace-regexp-in-string " +" "_" (match-string 1 name)))))))
+      (replace-regexp-in-string " +" "_" (match-string 1 name)))))
+   ((string= method "def")
+    name)))
 
 (defun ruby-test-implementation-filename (&optional filename)
   "Returns the implementation filename for the current buffer's

--- a/ruby-test-mode.el
+++ b/ruby-test-mode.el
@@ -274,7 +274,8 @@ second element."
     (if (re-search-backward (concat "^[ \t]*\\(def\\|test\\|it\\|should\\)[ \t]+"
                                     "\\([\"']\\(.*?\\)[\"']\\|" ruby-symbol-re "*\\)"
                                     "[ \t]*") nil t)
-        (let ((name (match-string 3))
+        (let ((name (or (match-string 3)
+                        (match-string 2)))
               (method (match-string 1)))
           (ruby-test-testcase-name name method)))))
 
@@ -287,6 +288,8 @@ second element."
     name)
    ((string= name "setup")
     nil)
+   ((string= method "def")
+    name)
    ((string-match "^[\"']\\(.*\\)[\"']$" name)
     (replace-regexp-in-string
      "\\?" "\\\\\\\\?"

--- a/test/ruby-test-mode-test.el
+++ b/test/ruby-test-mode-test.el
@@ -65,3 +65,13 @@
                  (ruby-test-find-testcase-at "unit_test.rb" 5)))
   (should (equal "test_one"
                  (ruby-test-find-testcase-at "unit_test.rb" 6))))
+
+
+(ert-deftest ruby-test-testcase-name-saves-position ()
+  (find-file "test/unit_test.rb")
+  (with-current-buffer "unit_test.rb"
+    (let ((target-line 5))
+      (goto-line target-line)
+      (should (equal "test_one"
+                     (ruby-test-find-testcase-at "unit_test.rb" target-line)))
+      (should (equal target-line (line-number-at-pos))))))

--- a/test/ruby-test-mode-test.el
+++ b/test/ruby-test-mode-test.el
@@ -10,8 +10,7 @@
   (should (equal "project/test/file_test.rb"
                  (ruby-test-unit-filename "project/lib/file.rb")))
   (should (equal "project/path/file_test.rb"
-                 (ruby-test-unit-filename "project/path/file.rb")))
-  )
+                 (ruby-test-unit-filename "project/path/file.rb"))))
 
 (ert-deftest ruby-test-find-target-filename ()
   (let ((mapping '(("\\(.*\\)\\(.rb\\)" "\\1_test.rb" "other/\\1_test.rb"
@@ -35,7 +34,8 @@
                  (ruby-test-testcase-name "\"test with parenthesis (somewhere)\"" "def")))
   (should (equal "test with spaces from minitest"
                  (ruby-test-testcase-name "test with spaces from minitest" "it")))
-  )
+  (should (equal "test_method_with_def"
+                 (ruby-test-testcase-name "test_method_with_def" "def"))))
 
 (ert-deftest ruby-test-specification-filename ()
   (should (equal "project/spec/models/file_spec.rb"
@@ -55,5 +55,13 @@
   (should (equal "project/something/file_spec.rb"
                  (ruby-test-specification-filename "project/something/file.rb")))
   (should (equal "project/spec/javascripts/file_spec.coffee"
-                 (ruby-test-specification-filename "project/app/assets/javascripts/file.coffee")))
-  )
+                 (ruby-test-specification-filename "project/app/assets/javascripts/file.coffee"))))
+
+(ert-deftest ruby-test-testcase-name-test ()
+  (find-file "test/unit_test.rb")
+  (should (equal "test_one"
+                 (ruby-test-find-testcase-at "unit_test.rb" 4)))
+  (should (equal "test_one"
+                 (ruby-test-find-testcase-at "unit_test.rb" 5)))
+  (should (equal "test_one"
+                 (ruby-test-find-testcase-at "unit_test.rb" 6))))

--- a/test/unit_test.rb
+++ b/test/unit_test.rb
@@ -1,0 +1,7 @@
+require 'test/unit'
+
+class FooTest < Test::Unit::TestCase
+  def test_one
+    assert_equal 1, 1
+  end
+end


### PR DESCRIPTION
I got tired of the point hopping to the line that the test name was defined on. This PR keeps the point in the correct position.