### PR TITLE
Switched to Cider bindings

### DIFF
--- a/README.org
+++ b/README.org
@@ -9,11 +9,11 @@
 
    ruby-test-mode comes with some default keybindings:
 
-   | Binding   | Action                                                             |
-   |-----------+--------------------------------------------------------------------|
-   | ~C-c C-,​~ | Run the current buffer's file as an unit test or an rspec example. |
-   | ~C-c M-,​~ | Runs the unit test or rspec example at the current buffer's point. |
-   | ~C-c C-s~ | Toggle between implementation and test/example files.              |
+   | Binding                                  | Action                                                             |
+   |------------------------------------------+--------------------------------------------------------------------|
+   | ~C-c C-t n~ @@html:<br/>@@ ~C-c C-t C-n~ | Run the current buffer's file as an unit test or an rspec example. |
+   | ~C-c C-t t~ @@html:<br/>@@ ~C-c C-t C-t~ | Runs the unit test or rspec example at the current buffer's point. |
+   | ~C-c C-s~                                | Toggle between implementation and test/example files.              |
 
 ** License
 

--- a/ruby-test-mode.el
+++ b/ruby-test-mode.el
@@ -34,13 +34,13 @@
 
 ;; Keybindings:
 ;;
-;; C-c C-,   - Runs the current buffer's file as an unit test or an
-;;             rspec example.
+;; C-c C-t n    - Runs the current buffer's file as an unit test or an
+;; C-c C-t C-n    rspec example.
 ;;
-;; C-c M-,   - Runs the unit test or rspec example at the current buffer's
-;;             buffer's point.
+;; C-c C-t t    - Runs the unit test or rspec example at the current buffer's
+;; C-c C-t C-t    buffer's point.
 ;;
-;; C-c C-s   - Toggle between implementation and test/example files.
+;; C-c C-s      - Toggle between implementation and test/example files.
 
 (require 'ruby-mode)
 (require 'pcre2el)
@@ -63,9 +63,11 @@ Test Driven Development in Ruby."
 
 (defvar ruby-test-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "C-c C-,") 'ruby-test-run)
-    (define-key map (kbd "C-c M-,") 'ruby-test-run-at-point)
-    (define-key map (kbd "C-c C-s") 'ruby-test-toggle-implementation-and-specification)
+    (define-key map (kbd "C-c C-t n")   'ruby-test-run)
+    (define-key map (kbd "C-c C-t C-n") 'ruby-test-run)
+    (define-key map (kbd "C-c C-t t")   'ruby-test-run-at-point)
+    (define-key map (kbd "C-c C-t C-t") 'ruby-test-run-at-point)
+    (define-key map (kbd "C-c C-s")     'ruby-test-toggle-implementation-and-specification)
     map)
   "The keymap used in `ruby-test-mode' buffers.")
 


### PR DESCRIPTION
I found these testing bindings [here](https://github.com/clojure-emacs/cider/blob/master/doc/running_tests.md). However,`C-c C-s` remains because I could not find a Cider equivalent.