### PR TITLE
Fix bug with regex.

### DIFF
--- a/ruby-test-mode.el
+++ b/ruby-test-mode.el
@@ -302,7 +302,7 @@ and replace the match with the second element."
       (end-of-line)
       (message "%s:%s" (current-buffer) (point))
       (if (re-search-backward (concat "^[ \t]*\\(def\\|test\\|it\\|should\\)[ \t]+"
-                                      "\\([\"']\\(.*?\\)[\"']\\|" ruby-symbol-re "*\\)"
+                                      "\\(\\([\"'].*?[\"']\\)\\|" ruby-symbol-re "*\\)"
                                       "[ \t]*") nil t)
           (let ((name (or (match-string 3)
                           (match-string 2)))


### PR DESCRIPTION
Fixes #48 

`ruby-test-testcase-name` expects us to preserve the quotes for it, we stripped them in the regex, this is ensuring we preserve the quotes in the match and fixing the bug.